### PR TITLE
Add validation tests and enforce required username

### DIFF
--- a/lib/validation/validation.js
+++ b/lib/validation/validation.js
@@ -10,7 +10,7 @@ export const infoSubmissionSchema = Joi.object({
     }),
   username: Joi.string()
     .max(35)
-    // .required()
+    .required()
     .messages({
       "string.empty": "Username is required",
       "string.max": "Username cannot exceed 35 characters",

--- a/lib/validation/validation.test.js
+++ b/lib/validation/validation.test.js
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const validationModule = import('./validation.js');
+
+test('invalid email formats', async () => {
+  const { infoSubmissionSchema, formValidation } = await validationModule;
+  const data = {
+    email: 'invalid-email',
+    username: 'user',
+    verificationCode: '123456',
+    termsAccepted: 'on',
+  };
+  const result = formValidation(data, infoSubmissionSchema);
+  assert.ok(result.error);
+  assert.equal(result.error.email, 'Enter a valid email');
+});
+
+test('missing username and verification code fields', async () => {
+  const { infoSubmissionSchema, formValidation } = await validationModule;
+  const data = {
+    email: 'test@example.com',
+    termsAccepted: 'on',
+  };
+  const result = formValidation(data, infoSubmissionSchema);
+  assert.ok(result.error);
+  assert.equal(result.error.username, 'username is required');
+  assert.equal(result.error.verificationCode, 'verificationCode is required');
+});
+
+test('successful validation with all required fields', async () => {
+  const { infoSubmissionSchema, formValidation } = await validationModule;
+  const data = {
+    email: 'test@example.com',
+    username: 'user',
+    verificationCode: '123456',
+    termsAccepted: 'on',
+  };
+  const result = formValidation(data, infoSubmissionSchema);
+  assert.deepEqual(result, { success: 'User input validation successful' });
+});


### PR DESCRIPTION
## Summary
- mark `username` field as required in validation schema
- add node:test suite covering invalid email, missing fields, and successful validation

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_6896726e3f648320a24d540f911fb37b